### PR TITLE
gcc-10 fix - Fixes the following compilation error:

### DIFF
--- a/lib/braille-lib/inc/braille-lib.h
+++ b/lib/braille-lib/inc/braille-lib.h
@@ -46,7 +46,7 @@
 // C D
 // E F
 // G H
-enum brailleBitsEnumTypeTag
+static enum brailleBitsEnumTypeTag
 {
     FIELD_A = 1 << 0,
     FIELD_B = 1 << 3,


### PR DESCRIPTION
```
gcc ./lib/braille-lib/src/braille-lib.c ./mod/zenmon-box/src/zenmon-box.c ./mod/zenmon-dot/src/zenmon-dot.c ./mod/zenmon-num/src/zenmon-num.c ./src/zenmon.c -I./cfg -I./inc -I./lib -I./lib/braille-lib -I./lib/braille-lib/inc -I./lib/braille-lib/src -I./mod -I./mod/zenmon-box -I./mod/zenmon-box/inc -I./mod/zenmon-box/src -I./mod/zenmon-dot -I./mod/zenmon-dot/inc -I./mod/zenmon-dot/src -I./mod/zenmon-num -I./mod/zenmon-num/inc -I./mod/zenmon-num/src -I./res -I./src   -o ./out/zenmon
/usr/lib/gcc/x86_64-pc-linux-gnu/10.0.1/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/ccLZVcZ5.o:(.bss+0x0): multiple definition of `brailleBitsEnumType'; /tmp/ccEhI1w7.o:(.bss+0x0): first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/10.0.1/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/ccchJuJ8.o:(.bss+0x0): multiple definition of `brailleBitsEnumType'; /tmp/ccEhI1w7.o:(.bss+0x0): first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/10.0.1/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/cc6hxet8.o:(.bss+0x0): multiple definition of `brailleBitsEnumType'; /tmp/ccEhI1w7.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
make: *** [makefile:23: zenmon] Error 1
```